### PR TITLE
feat: Add start date to plan week

### DIFF
--- a/api/db/migrations/20210319022440_add_start_date_to_plan_week/migration.sql
+++ b/api/db/migrations/20210319022440_add_start_date_to_plan_week/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Made the column `planWeekId` on table `PlanWorkout` required. The migration will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "PlanWeek" ADD COLUMN     "startDate" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "PlanWorkout" ALTER COLUMN "planWeekId" SET NOT NULL;

--- a/api/db/migrations/20210319024208_make_start_date_required/migration.sql
+++ b/api/db/migrations/20210319024208_make_start_date_required/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `startDate` on table `PlanWeek` required. The migration will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "PlanWeek" ALTER COLUMN "startDate" SET NOT NULL;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -27,7 +27,7 @@ model PlanWeek {
   id           Int           @id @default(autoincrement())
   planWorkouts PlanWorkout[]
   weekNumber   Int
-  startDate    DateTime?
+  startDate    DateTime
   intention    String?
   Plan         Plan?         @relation(fields: [planId], references: [id])
   planId       Int?

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -27,6 +27,7 @@ model PlanWeek {
   id           Int           @id @default(autoincrement())
   planWorkouts PlanWorkout[]
   weekNumber   Int
+  startDate    DateTime?
   intention    String?
   Plan         Plan?         @relation(fields: [planId], references: [id])
   planId       Int?

--- a/api/src/graphql/planWeeks.sdl.js
+++ b/api/src/graphql/planWeeks.sdl.js
@@ -3,6 +3,7 @@ export const schema = gql`
     id: Int!
     planWorkouts: [PlanWorkout]!
     weekNumber: Int!
+    startDate: DateTime!
     intention: String
     plan: Plan
     planId: Int

--- a/api/src/services/plans/plans.js
+++ b/api/src/services/plans/plans.js
@@ -12,5 +12,7 @@ export const plan = ({ id }) => {
 
 export const Plan = {
   planWeeks: (_obj, { root }) =>
-    db.plan.findUnique({ where: { id: root.id } }).planWeeks(),
+    db.plan
+      .findUnique({ where: { id: root.id } })
+      .planWeeks({ orderBy: { startDate: 'asc' } }),
 }

--- a/web/src/components/EditPlan/EditPlan.js
+++ b/web/src/components/EditPlan/EditPlan.js
@@ -63,6 +63,9 @@ const PlanWeeks = ({ planWeeks }) => {
       ...planWeekDays.map((day) => day.workouts.length)
     )
     const height = 90 * maxWorkoutsPerDay + 8 * (maxWorkoutsPerDay + 1)
+    const { startDateFormatted, endDateFormatted } = formatStartAndEndDates(
+      planWeek
+    )
 
     return (
       <Stack key={planWeek.id}>
@@ -70,7 +73,8 @@ const PlanWeeks = ({ planWeeks }) => {
         <Flex direction="row" justifyContent="space-between">
           <HStack>
             <Heading fontSize="lg" as="h3" color="gray.500">
-              Week {planWeek.weekNumber}:
+              Week {planWeek.weekNumber} ({startDateFormatted} -{' '}
+              {endDateFormatted}):
             </Heading>
             <Heading fontSize="lg" as="h4">
               {planWeek.intention}
@@ -138,6 +142,20 @@ const PlanWorkout = ({ workout }) => {
       </Flex>
     </Stack>
   )
+}
+
+function formatStartAndEndDates(planWeek) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeZone: 'UTC',
+  })
+  const startDate = new Date(planWeek.startDate)
+  const startDateFormatted = formatter.format(startDate)
+  const endDate = new Date(startDate)
+  endDate.setDate(startDate.getDate() + 6)
+  const endDateFormatted = formatter.format(endDate)
+
+  return { startDateFormatted, endDateFormatted }
 }
 
 export function mapPlanWorkoutsToDays(planWorkouts) {

--- a/web/src/components/EditPlanCell/EditPlanCell.js
+++ b/web/src/components/EditPlanCell/EditPlanCell.js
@@ -8,6 +8,7 @@ export const QUERY = gql`
       planWeeks {
         id
         weekNumber
+        startDate
         intention
         planWorkouts {
           id

--- a/web/src/components/EditPlanCell/EditPlanCell.mock.js
+++ b/web/src/components/EditPlanCell/EditPlanCell.mock.js
@@ -7,6 +7,7 @@ export const standard = (/* vars, { ctx, req } */) => ({
       {
         id: 12,
         weekNumber: 1,
+        startDate: '2021-01-26T00:00:00.000',
         intention: 'start it up',
         planWorkouts: [
           {
@@ -36,6 +37,7 @@ export const standard = (/* vars, { ctx, req } */) => ({
       {
         id: 23,
         weekNumber: 2,
+        startDate: '2021-02-04T00:00:00.000',
         intention: 'finish it',
       },
     ],


### PR DESCRIPTION
I haven't yet been showing actual dates on a plan; this PR adds them.

![image](https://user-images.githubusercontent.com/1627089/111726643-52489780-8837-11eb-9fdb-bfe89f43aa68.png)

Follow the trail of commits to see the places I'm updating in redwood. I worked from back-end toward front. 

Note: The db migration is broken into two steps - 1. add the new column, then 2. make it required. I did this so that I could manually update rows locally in between the two steps, and wouldn't have to worry about either (a) the migration failing because I had existing data without values in that column, or (b) setting a default value for the column, which I can't reasonably predict.