### PR TITLE
Refetch edit plan page on modal close

### DIFF
--- a/web/src/components/EditPlan/EditPlan.js
+++ b/web/src/components/EditPlan/EditPlan.js
@@ -6,21 +6,20 @@ import {
   Flex,
   Heading,
   HStack,
-  Link,
   Stack,
   Text,
   Tooltip,
   useDisclosure,
   VisuallyHidden,
 } from '@chakra-ui/react'
-import { Link as RouterLink, routes } from '@redwoodjs/router'
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import EditPlanWorkoutModalCell from '../EditPlanWorkoutModalCell'
 import NewPlanWorkoutModalCell from '../NewPlanWorkoutModalCell'
+import { EditPlanContext } from '../EditPlanCell/EditPlanContext'
 
 const daysOfWeek = ['M', 'T', 'W', 'R', 'F', 'S', 'S']
 
-const EditPlan = ({ plan, refetch }) => {
+const EditPlan = ({ plan }) => {
   if (!plan) {
     return null
   }
@@ -44,7 +43,7 @@ const EditPlan = ({ plan, refetch }) => {
           })}
         </HStack>
         <Stack>
-          <PlanWeeks planWeeks={plan.planWeeks} refetch={refetch} />
+          <PlanWeeks planWeeks={plan.planWeeks} />
         </Stack>
       </Stack>
     </Container>
@@ -52,7 +51,9 @@ const EditPlan = ({ plan, refetch }) => {
 }
 
 const workoutCardHeight = 100
-const PlanWeeks = ({ planWeeks, refetch }) => {
+const PlanWeeks = ({ planWeeks }) => {
+  const { refetch } = useContext(EditPlanContext)
+
   return planWeeks.map((planWeek) => {
     const { isOpen, onOpen, onClose } = useDisclosure()
 
@@ -109,7 +110,6 @@ const PlanWeeks = ({ planWeeks, refetch }) => {
                 planWeekDay={planWeekDay}
                 height={`${height}px`}
                 key={`${planWeek.id}|${planWeekDay.dayOfWeek}`}
-                refetch={refetch}
               />
             ))}
           </HStack>
@@ -120,7 +120,7 @@ const PlanWeeks = ({ planWeeks, refetch }) => {
   })
 }
 
-export const PlanWeekDay = ({ planWeek, planWeekDay, height, refetch }) => {
+export const PlanWeekDay = ({ planWeek, planWeekDay, height }) => {
   return (
     <Box w="160px" h={height} bgColor="gray.100">
       {planWeekDay?.workouts.map((workout) => {
@@ -129,7 +129,6 @@ export const PlanWeekDay = ({ planWeek, planWeekDay, height, refetch }) => {
             planWeek={planWeek}
             workout={workout}
             key={`workout-${workout.id}`}
-            refetch={refetch}
           />
         )
       })}
@@ -137,7 +136,8 @@ export const PlanWeekDay = ({ planWeek, planWeekDay, height, refetch }) => {
   )
 }
 
-const PlanWorkout = ({ planWeek, workout, refetch }) => {
+const PlanWorkout = ({ planWeek, workout }) => {
+  const { refetch } = useContext(EditPlanContext)
   const [hovered, setHovered] = useState(false)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const borderColor = hovered ? 'green.600' : 'gray.200'

--- a/web/src/components/EditPlan/EditPlan.js
+++ b/web/src/components/EditPlan/EditPlan.js
@@ -12,10 +12,10 @@ import {
   useDisclosure,
   VisuallyHidden,
 } from '@chakra-ui/react'
-import { useContext, useState } from 'react'
+import { useState } from 'react'
 import EditPlanWorkoutModalCell from '../EditPlanWorkoutModalCell'
 import NewPlanWorkoutModalCell from '../NewPlanWorkoutModalCell'
-import { EditPlanContext } from '../EditPlanCell/EditPlanContext'
+import { useEditPlanContext } from '../EditPlanCell/EditPlanContext'
 
 const daysOfWeek = ['M', 'T', 'W', 'R', 'F', 'S', 'S']
 
@@ -52,7 +52,7 @@ const EditPlan = ({ plan }) => {
 
 const workoutCardHeight = 100
 const PlanWeeks = ({ planWeeks }) => {
-  const { refetch } = useContext(EditPlanContext)
+  const { refetch } = useEditPlanContext()
 
   return planWeeks.map((planWeek) => {
     const { isOpen, onOpen, onClose } = useDisclosure()
@@ -137,7 +137,7 @@ export const PlanWeekDay = ({ planWeek, planWeekDay, height }) => {
 }
 
 const PlanWorkout = ({ planWeek, workout }) => {
-  const { refetch } = useContext(EditPlanContext)
+  const { refetch } = useEditPlanContext()
   const [hovered, setHovered] = useState(false)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const borderColor = hovered ? 'green.600' : 'gray.200'

--- a/web/src/components/EditPlan/EditPlan.js
+++ b/web/src/components/EditPlan/EditPlan.js
@@ -20,7 +20,7 @@ import NewPlanWorkoutModalCell from '../NewPlanWorkoutModalCell'
 
 const daysOfWeek = ['M', 'T', 'W', 'R', 'F', 'S', 'S']
 
-const EditPlan = ({ plan }) => {
+const EditPlan = ({ plan, refetch }) => {
   if (!plan) {
     return null
   }
@@ -44,7 +44,7 @@ const EditPlan = ({ plan }) => {
           })}
         </HStack>
         <Stack>
-          <PlanWeeks planWeeks={plan.planWeeks} />
+          <PlanWeeks planWeeks={plan.planWeeks} refetch={refetch} />
         </Stack>
       </Stack>
     </Container>
@@ -52,12 +52,18 @@ const EditPlan = ({ plan }) => {
 }
 
 const workoutCardHeight = 100
-const PlanWeeks = ({ planWeeks }) => {
+const PlanWeeks = ({ planWeeks, refetch }) => {
   return planWeeks.map((planWeek) => {
     const { isOpen, onOpen, onClose } = useDisclosure()
 
     const modal = isOpen ? (
-      <NewPlanWorkoutModalCell planWeekID={planWeek.id} onClose={onClose} />
+      <NewPlanWorkoutModalCell
+        planWeekID={planWeek.id}
+        onClose={() => {
+          onClose()
+          refetch()
+        }}
+      />
     ) : null
 
     const planWeekDays = mapPlanWorkoutsToDays(planWeek.planWorkouts || [])
@@ -103,6 +109,7 @@ const PlanWeeks = ({ planWeeks }) => {
                 planWeekDay={planWeekDay}
                 height={`${height}px`}
                 key={`${planWeek.id}|${planWeekDay.dayOfWeek}`}
+                refetch={refetch}
               />
             ))}
           </HStack>
@@ -113,7 +120,7 @@ const PlanWeeks = ({ planWeeks }) => {
   })
 }
 
-export const PlanWeekDay = ({ planWeek, planWeekDay, height }) => {
+export const PlanWeekDay = ({ planWeek, planWeekDay, height, refetch }) => {
   return (
     <Box w="160px" h={height} bgColor="gray.100">
       {planWeekDay?.workouts.map((workout) => {
@@ -122,6 +129,7 @@ export const PlanWeekDay = ({ planWeek, planWeekDay, height }) => {
             planWeek={planWeek}
             workout={workout}
             key={`workout-${workout.id}`}
+            refetch={refetch}
           />
         )
       })}
@@ -129,7 +137,7 @@ export const PlanWeekDay = ({ planWeek, planWeekDay, height }) => {
   )
 }
 
-const PlanWorkout = ({ planWeek, workout }) => {
+const PlanWorkout = ({ planWeek, workout, refetch }) => {
   const [hovered, setHovered] = useState(false)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const borderColor = hovered ? 'green.600' : 'gray.200'
@@ -148,7 +156,10 @@ const PlanWorkout = ({ planWeek, workout }) => {
     <EditPlanWorkoutModalCell
       id={workout.id}
       planWeekID={planWeek.id}
-      onClose={onClose}
+      onClose={() => {
+        onClose()
+        refetch()
+      }}
     />
   ) : null
 

--- a/web/src/components/EditPlan/EditPlan.js
+++ b/web/src/components/EditPlan/EditPlan.js
@@ -86,8 +86,8 @@ const PlanWeeks = ({ planWeeks }) => {
     )
 
     return (
-      <>
-        <Stack key={planWeek.id}>
+      <React.Fragment key={planWeek.id}>
+        <Stack>
           <Divider mt="3" mb="2" />
           <Flex direction="row" justifyContent="space-between">
             <HStack>
@@ -115,7 +115,7 @@ const PlanWeeks = ({ planWeeks }) => {
           </HStack>
         </Stack>
         {modal}
-      </>
+      </React.Fragment>
     )
   })
 }

--- a/web/src/components/EditPlanCell/EditPlanCell.js
+++ b/web/src/components/EditPlanCell/EditPlanCell.js
@@ -1,4 +1,5 @@
 import EditPlan from '../EditPlan'
+import { EditPlanContextProvider } from './EditPlanContext'
 
 export const QUERY = gql`
   query EditPlanQuery($id: Int!) {
@@ -34,5 +35,9 @@ export const Empty = () => <div>Empty</div>
 export const Failure = ({ error }) => <div>Error: {error.message}</div>
 
 export const Success = ({ plan, refetch }) => {
-  return <EditPlan plan={plan} refetch={refetch}></EditPlan>
+  return (
+    <EditPlanContextProvider refetch={refetch}>
+      <EditPlan plan={plan} />
+    </EditPlanContextProvider>
+  )
 }

--- a/web/src/components/EditPlanCell/EditPlanCell.js
+++ b/web/src/components/EditPlanCell/EditPlanCell.js
@@ -33,6 +33,6 @@ export const Empty = () => <div>Empty</div>
 
 export const Failure = ({ error }) => <div>Error: {error.message}</div>
 
-export const Success = ({ plan }) => {
-  return <EditPlan plan={plan}></EditPlan>
+export const Success = ({ plan, refetch }) => {
+  return <EditPlan plan={plan} refetch={refetch}></EditPlan>
 }

--- a/web/src/components/EditPlanCell/EditPlanContext.js
+++ b/web/src/components/EditPlanCell/EditPlanContext.js
@@ -1,3 +1,5 @@
+import { useContext } from 'react'
+
 export const EditPlanContext = React.createContext({})
 
 export function EditPlanContextProvider({ refetch, children }) {
@@ -7,4 +9,10 @@ export function EditPlanContextProvider({ refetch, children }) {
       {children}
     </EditPlanContext.Provider>
   )
+}
+
+export function useEditPlanContext() {
+  const value = useContext(EditPlanContext)
+
+  return value
 }

--- a/web/src/components/EditPlanCell/EditPlanContext.js
+++ b/web/src/components/EditPlanCell/EditPlanContext.js
@@ -1,0 +1,10 @@
+export const EditPlanContext = React.createContext({})
+
+export function EditPlanContextProvider({ refetch, children }) {
+  const value = { refetch }
+  return (
+    <EditPlanContext.Provider value={value}>
+      {children}
+    </EditPlanContext.Provider>
+  )
+}


### PR DESCRIPTION
Thank you [redwood community](https://community.redwoodjs.com/t/how-to-refresh-a-cell-due-to-stale-data/1733/2)!

This refetches the EditPlanCell when a workout is added or edited, using the `refetch` prop available to the `EditPlanCell`. 

There was some prop-drilling I had to do to access the prop throughout my component tree, so I decided to put it in a context object -- I think I might like that patter -- put all the "cell" things in a context object at the top if a cell's tree. Maybe there's even a `CellContext` and `useCellContext` abstraction I would use across them all, instead of building them per cell?

## What it looks like


https://user-images.githubusercontent.com/1627089/115180691-d6db3f80-a09b-11eb-97b8-b8bf111168f7.mp4

