### PR TITLE
fix: move cells inside modal to avoid "loading" in underlying grid

### DIFF
--- a/web/src/components/EditPlan/EditPlan.js
+++ b/web/src/components/EditPlan/EditPlan.js
@@ -13,6 +13,7 @@ import {
   VisuallyHidden,
 } from '@chakra-ui/react'
 import { useState } from 'react'
+import { PlanWorkoutModal } from '../PlanWorkoutModal'
 import EditPlanWorkoutModalCell from '../EditPlanWorkoutModalCell'
 import NewPlanWorkoutModalCell from '../NewPlanWorkoutModalCell'
 import { useEditPlanContext } from '../EditPlanCell/EditPlanContext'
@@ -56,16 +57,6 @@ const PlanWeeks = ({ planWeeks }) => {
 
   return planWeeks.map((planWeek) => {
     const { isOpen, onOpen, onClose } = useDisclosure()
-
-    const modal = isOpen ? (
-      <NewPlanWorkoutModalCell
-        planWeekID={planWeek.id}
-        onClose={() => {
-          onClose()
-          refetch()
-        }}
-      />
-    ) : null
 
     const planWeekDays = mapPlanWorkoutsToDays(planWeek.planWorkouts || [])
 
@@ -114,7 +105,15 @@ const PlanWeeks = ({ planWeeks }) => {
             ))}
           </HStack>
         </Stack>
-        {modal}
+        <PlanWorkoutModal title="Add Workout" isOpen={isOpen} onClose={onClose}>
+          <NewPlanWorkoutModalCell
+            planWeekID={planWeek.id}
+            onSaved={() => {
+              onClose()
+              refetch()
+            }}
+          />
+        </PlanWorkoutModal>
       </React.Fragment>
     )
   })
@@ -152,17 +151,6 @@ const PlanWorkout = ({ planWeek, workout }) => {
   }
   const bgColor = workout.isKeyWorkout ? 'green.50' : 'white'
 
-  const modal = isOpen ? (
-    <EditPlanWorkoutModalCell
-      id={workout.id}
-      planWeekID={planWeek.id}
-      onClose={() => {
-        onClose()
-        refetch()
-      }}
-    />
-  ) : null
-
   return (
     <>
       <Stack
@@ -199,7 +187,16 @@ const PlanWorkout = ({ planWeek, workout }) => {
           </Tooltip>
         </Stack>
       </Stack>
-      {modal}
+      <PlanWorkoutModal title="Edit Workout" isOpen={isOpen} onClose={onClose}>
+        <EditPlanWorkoutModalCell
+          id={workout.id}
+          planWeekID={planWeek.id}
+          onSaved={() => {
+            onClose()
+            refetch()
+          }}
+        />
+      </PlanWorkoutModal>
     </>
   )
 }

--- a/web/src/components/EditPlanWorkoutModalCell/EditPlanWorkoutModalCell.js
+++ b/web/src/components/EditPlanWorkoutModalCell/EditPlanWorkoutModalCell.js
@@ -1,10 +1,3 @@
-import {
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalCloseButton,
-} from '@chakra-ui/react'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 import { PlanWorkoutModalForm } from '../PlanWorkoutModalForm'
@@ -81,13 +74,13 @@ export const Empty = () => <div>Empty</div>
 
 export const Failure = ({ error }) => <div>Error: {error.message}</div>
 
-export const Success = ({ planWorkout, activities, planWeek, onClose }) => {
+export const Success = ({ planWorkout, activities, planWeek, onSaved }) => {
   const [updatePlanWorkout, { loading, error }] = useMutation(
     UPDATE_PLAN_WORKOUT_MUTATION,
     {
       onCompleted: () => {
         toast.success('Workout updated!')
-        onClose()
+        onSaved()
       },
     }
   )
@@ -95,7 +88,7 @@ export const Success = ({ planWorkout, activities, planWeek, onClose }) => {
   const [deletePlanWorkout] = useMutation(DELETE_PLAN_WORKOUT_MUTATION, {
     onCompleted: () => {
       toast.success('Workout deleted!')
-      onClose()
+      onSaved()
     },
   })
 
@@ -108,27 +101,14 @@ export const Success = ({ planWorkout, activities, planWeek, onClose }) => {
   }
 
   return (
-    <Modal
-      size="xl"
-      closeOnOverlayClick={false}
-      scrollBehavior="outside"
-      isOpen
-      onClose={onClose}
-    >
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>Edit Workout</ModalHeader>
-        <ModalCloseButton />
-        <PlanWorkoutModalForm
-          activities={activities}
-          planWeek={planWeek}
-          planWorkout={planWorkout}
-          onSave={onSave}
-          onDelete={onDelete}
-          loading={loading}
-          error={error}
-        />
-      </ModalContent>
-    </Modal>
+    <PlanWorkoutModalForm
+      activities={activities}
+      planWeek={planWeek}
+      planWorkout={planWorkout}
+      onSave={onSave}
+      onDelete={onDelete}
+      loading={loading}
+      error={error}
+    />
   )
 }

--- a/web/src/components/NewPlanWorkoutModalCell/NewPlanWorkoutModalCell.js
+++ b/web/src/components/NewPlanWorkoutModalCell/NewPlanWorkoutModalCell.js
@@ -1,10 +1,3 @@
-import {
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalCloseButton,
-} from '@chakra-ui/react'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 import { PlanWorkoutModalForm } from '../PlanWorkoutModalForm'
@@ -41,13 +34,13 @@ export const Empty = () => <div>Empty</div>
 
 export const Failure = ({ error }) => <div>Error: {error.message}</div>
 
-export const Success = ({ activities, planWeek, onClose }) => {
+export const Success = ({ activities, planWeek, onSaved }) => {
   const [createPlanWorkout, { loading, error }] = useMutation(
     CREATE_PLAN_WORKOUT_MUTATION,
     {
       onCompleted: () => {
         toast.success('Workout created!')
-        onClose()
+        onSaved()
       },
     }
   )
@@ -59,25 +52,12 @@ export const Success = ({ activities, planWeek, onClose }) => {
   // todo: move this into EditPlan, & control things from there
   //   so that loading in this component appears in the modal.
   return (
-    <Modal
-      size="xl"
-      closeOnOverlayClick={false}
-      scrollBehavior="outside"
-      isOpen
-      onClose={onClose}
-    >
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>Add Workout</ModalHeader>
-        <ModalCloseButton />
-        <PlanWorkoutModalForm
-          activities={activities}
-          planWeek={planWeek}
-          onSave={onSave}
-          loading={loading}
-          error={error}
-        />
-      </ModalContent>
-    </Modal>
+    <PlanWorkoutModalForm
+      activities={activities}
+      planWeek={planWeek}
+      onSave={onSave}
+      loading={loading}
+      error={error}
+    />
   )
 }

--- a/web/src/components/PlanWorkoutModal/PlanWorkoutModal.js
+++ b/web/src/components/PlanWorkoutModal/PlanWorkoutModal.js
@@ -1,0 +1,28 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+} from '@chakra-ui/react'
+
+export const PlanWorkoutModal = ({ isOpen, onClose, title, children }) => {
+  return (
+    <Modal
+      size="xl"
+      closeOnOverlayClick={false}
+      scrollBehavior="outside"
+      isOpen={isOpen}
+      onClose={onClose}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{title}</ModalHeader>
+        <ModalCloseButton />
+        {children}
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default PlanWorkoutModal

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>Pendulina</title>
   </head>
   <body>
     <div id="redwood-app">


### PR DESCRIPTION
Addresses #36 

The component tree used to be: 

```
<EditPlan>
  <AddModalCell>
    <Modal>
  <EditModalCell>
    <Modal>

```

But this resulted in showing the "add" and "edit" loading states in the EditPlan grid, like this: 

![loading-before](https://user-images.githubusercontent.com/1627089/116955444-269f3680-ac58-11eb-95be-7a095481f125.gif)


Now the component tree is:

```
<EditPlan>
  <Modal>
    <AddModalCell>
  <Modal>
    <EditModalCell>
```

which means the `Loading` state of `AddModalCell`/`EditModalCell` show up inside the modals, where they belong:

![loadingafter](https://user-images.githubusercontent.com/1627089/116955334-e2ac3180-ac57-11eb-8c9e-3ce24679a4b4.gif)
