### PR TITLE
Display react-icons for activities instead of emoji

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-hook-form": "^7.0.5"
+    "react-hook-form": "^7.0.5",
+    "react-icons": "^4.2.0"
   }
 }

--- a/web/src/components/ActivityIcon/ActivityIcon.js
+++ b/web/src/components/ActivityIcon/ActivityIcon.js
@@ -1,0 +1,39 @@
+import { Icon } from '@chakra-ui/react'
+import {
+  FaBiking,
+  FaWeightHanging,
+  FaOm,
+  FaRegCalendarAlt,
+  FaRunning,
+  FaSwimmer,
+  FaTrophy,
+} from 'react-icons/fa'
+
+export const ActivityIcon = ({ activity, color = 'gray.500' }) => {
+  const activityTheme = activityThemes[activity.name]
+  return <Icon as={activityTheme.icon} color={color} />
+}
+
+const activityThemes = {
+  Cycling: {
+    icon: FaBiking,
+  },
+  Event: {
+    icon: FaRegCalendarAlt,
+  },
+  Triathlon: {
+    icon: FaTrophy,
+  },
+  Running: {
+    icon: FaRunning,
+  },
+  Strength: {
+    icon: FaWeightHanging,
+  },
+  Swimming: {
+    icon: FaSwimmer,
+  },
+  Yoga: {
+    icon: FaOm,
+  },
+}

--- a/web/src/components/EditPlan/EditPlan.js
+++ b/web/src/components/EditPlan/EditPlan.js
@@ -17,6 +17,7 @@ import { PlanWorkoutModal } from '../PlanWorkoutModal'
 import EditPlanWorkoutModalCell from '../EditPlanWorkoutModalCell'
 import NewPlanWorkoutModalCell from '../NewPlanWorkoutModalCell'
 import { useEditPlanContext } from '../EditPlanCell/EditPlanContext'
+import { ActivityIcon } from '../ActivityIcon'
 
 const daysOfWeek = ['M', 'T', 'W', 'R', 'F', 'S', 'S']
 
@@ -169,7 +170,7 @@ const PlanWorkout = ({ planWeek, workout }) => {
           justifyContent="space-between"
           alignItems="center"
         >
-          <Text fontSize="2xl">{workout.activity.icon}</Text>
+          <ActivityIcon activity={workout.activity} />
           <ButtonWrapper>
             <Button size="xs" colorScheme="green" onClick={onOpen}>
               Edit

--- a/yarn.lock
+++ b/yarn.lock
@@ -13671,6 +13671,11 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-icons@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
+  integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
+
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
In working toward [my calendar redesign](https://67o49.csb.app/), this PR displays react-icons icons for activities instead of emojis. 

## before

![image](https://user-images.githubusercontent.com/1627089/118910910-e80dab00-b8ea-11eb-903d-7677e2ca37ad.png)


## after

![image](https://user-images.githubusercontent.com/1627089/118910951-f65bc700-b8ea-11eb-9a20-76e51b0eb4a2.png)

There's an issue with the height of the "Edit" button knocking things out of line, but I'm not worried about that right now, as this whole calendar UI will be revamped.
